### PR TITLE
fix: 入力フィールドのテキスト可視性を改善

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -149,7 +149,7 @@ export default function Home() {
             <div className="bg-white rounded-lg shadow-xl p-6 w-full max-w-md">
               <h2 className="text-xl font-semibold text-gray-900 mb-4">Delete Todo</h2>
               <p className="text-gray-600 mb-6">
-                Are you sure you want to delete "{deletingTodo.title}"? This action cannot be undone.
+                Are you sure you want to delete &quot;{deletingTodo.title}&quot;? This action cannot be undone.
               </p>
               <div className="flex gap-3 justify-end">
                 <button

--- a/src/components/TodoEditForm.tsx
+++ b/src/components/TodoEditForm.tsx
@@ -51,7 +51,7 @@ export default function TodoEditForm({ todo, onSubmit, onCancel, isSubmitting }:
               {...register('title', { required: 'Title is required' })}
               type="text"
               id="title"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900"
             />
             {errors.title && (
               <p className="mt-1 text-sm text-red-600">{errors.title.message}</p>
@@ -66,7 +66,7 @@ export default function TodoEditForm({ todo, onSubmit, onCancel, isSubmitting }:
               {...register('description')}
               id="description"
               rows={3}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900"
             />
           </div>
 
@@ -78,7 +78,7 @@ export default function TodoEditForm({ todo, onSubmit, onCancel, isSubmitting }:
               <select
                 {...register('status')}
                 id="status"
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900"
               >
                 <option value="TODO">TODO</option>
                 <option value="IN_PROGRESS">IN PROGRESS</option>
@@ -93,7 +93,7 @@ export default function TodoEditForm({ todo, onSubmit, onCancel, isSubmitting }:
               <select
                 {...register('priority')}
                 id="priority"
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900"
               >
                 <option value="LOW">LOW</option>
                 <option value="MEDIUM">MEDIUM</option>
@@ -110,7 +110,7 @@ export default function TodoEditForm({ todo, onSubmit, onCancel, isSubmitting }:
               {...register('dueDate')}
               type="date"
               id="dueDate"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900"
             />
           </div>
 

--- a/src/components/TodoForm.tsx
+++ b/src/components/TodoForm.tsx
@@ -47,7 +47,7 @@ export default function TodoForm({ onSubmit, onCancel, isSubmitting }: TodoFormP
               {...register('title', { required: 'Title is required' })}
               type="text"
               id="title"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900"
             />
             {errors.title && (
               <p className="mt-1 text-sm text-red-600">{errors.title.message}</p>
@@ -62,7 +62,7 @@ export default function TodoForm({ onSubmit, onCancel, isSubmitting }: TodoFormP
               {...register('description')}
               id="description"
               rows={3}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900"
             />
           </div>
 
@@ -74,7 +74,7 @@ export default function TodoForm({ onSubmit, onCancel, isSubmitting }: TodoFormP
               <select
                 {...register('status')}
                 id="status"
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900"
               >
                 <option value="TODO">TODO</option>
                 <option value="IN_PROGRESS">IN PROGRESS</option>
@@ -89,7 +89,7 @@ export default function TodoForm({ onSubmit, onCancel, isSubmitting }: TodoFormP
               <select
                 {...register('priority')}
                 id="priority"
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900"
               >
                 <option value="LOW">LOW</option>
                 <option value="MEDIUM">MEDIUM</option>
@@ -106,7 +106,7 @@ export default function TodoForm({ onSubmit, onCancel, isSubmitting }: TodoFormP
               {...register('dueDate')}
               type="date"
               id="dueDate"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900"
             />
           </div>
 

--- a/src/components/__tests__/TodoEditForm.test.tsx
+++ b/src/components/__tests__/TodoEditForm.test.tsx
@@ -143,4 +143,26 @@ describe('TodoEditForm', () => {
     const dueDateInput = screen.getByLabelText(/due date/i) as HTMLInputElement;
     expect(dueDateInput.value).toBe('');
   });
+
+  it('has visible text in input fields', () => {
+    render(
+      <TodoEditForm
+        todo={mockTodo}
+        onSubmit={mockOnSubmit}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    const titleInput = screen.getByLabelText(/title/i);
+    const descriptionTextarea = screen.getByLabelText(/description/i);
+    const statusSelect = screen.getByLabelText(/status/i);
+    const prioritySelect = screen.getByLabelText(/priority/i);
+    const dueDateInput = screen.getByLabelText(/due date/i);
+
+    expect(titleInput).toHaveClass('text-gray-900');
+    expect(descriptionTextarea).toHaveClass('text-gray-900');
+    expect(statusSelect).toHaveClass('text-gray-900');
+    expect(prioritySelect).toHaveClass('text-gray-900');
+    expect(dueDateInput).toHaveClass('text-gray-900');
+  });
 });

--- a/src/components/__tests__/TodoForm.test.tsx
+++ b/src/components/__tests__/TodoForm.test.tsx
@@ -111,4 +111,25 @@ describe('TodoForm', () => {
     expect(screen.getByLabelText(/status/i)).toHaveValue('TODO');
     expect(screen.getByLabelText(/priority/i)).toHaveValue('MEDIUM');
   });
+
+  it('has visible text in input fields', () => {
+    render(
+      <TodoForm
+        onSubmit={mockOnSubmit}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    const titleInput = screen.getByLabelText(/title/i);
+    const descriptionTextarea = screen.getByLabelText(/description/i);
+    const statusSelect = screen.getByLabelText(/status/i);
+    const prioritySelect = screen.getByLabelText(/priority/i);
+    const dueDateInput = screen.getByLabelText(/due date/i);
+
+    expect(titleInput).toHaveClass('text-gray-900');
+    expect(descriptionTextarea).toHaveClass('text-gray-900');
+    expect(statusSelect).toHaveClass('text-gray-900');
+    expect(prioritySelect).toHaveClass('text-gray-900');
+    expect(dueDateInput).toHaveClass('text-gray-900');
+  });
 });


### PR DESCRIPTION
## 概要
Issue #7 の修正: 入力時テキストが白背景と同化する問題を解決

## 変更内容
- TodoFormとTodoEditFormの全入力フィールド（input, textarea, select）に`text-gray-900`クラスを追加
- 白背景でもテキストが適切に表示されるようになった
- テストケース追加で修正内容を検証
- ESLintエラー修正（HTMLエスケープ）

## テスト
- 既存テストに新しいテストケース追加
- `text-gray-900`クラスの存在を検証
- lint/テストが正常に通過

## 影響範囲
- TodoForm.tsx
- TodoEditForm.tsx
- 対応するテストファイル

🤖 Generated with [Claude Code](https://claude.ai/code)