### PR TITLE
fix: CIからVercelデプロイジョブを削除

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,29 +193,3 @@ jobs:
   #       path: playwright-report/
   #       retention-days: 30
 
-  deploy:
-    runs-on: ubuntu-latest
-    needs: [unit-test, build] # e2e-test temporarily removed
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '18'
-        cache: 'npm'
-
-    - name: Install Vercel CLI
-      run: npm install --global vercel@latest
-
-    - name: Pull Vercel Environment
-      run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-
-    - name: Build Project
-      run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-
-    - name: Deploy to Vercel
-      run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Summary
- CIワークフローから不要なVercelデプロイジョブを削除
- CI/CDパイプラインを軽量化し、テストとビルドのみに集中

## 背景
現在Vercelへのデプロイ予定がないにも関わらず、CIでVercelデプロイが実行されて認証エラーが発生していた問題を解消。

## 変更内容
- `.github/workflows/ci.yml`から`deploy`ジョブを削除
- Vercel関連のステップ（CLI インストール、環境設定、ビルド、デプロイ）を全て削除

## Test plan
- [x] CI/CDパイプラインがエラーなく実行される
- [x] unit-testとbuildジョブは正常に動作する

🤖 Generated with [Claude Code](https://claude.ai/code)