### PR TITLE
feat: ダークモード・テーマシステム実装

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,16 @@
 import '@testing-library/jest-dom'
+
+// Mock matchMedia
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});

--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -5,6 +5,7 @@ import Home from '../page';
 import { todoApi } from '@/lib/api';
 import { Todo } from '@/types/todo';
 import { AuthProvider } from '@/contexts/AuthContext';
+import { ThemeProvider } from '@/contexts/ThemeContext';
 
 jest.mock('@/lib/api');
 
@@ -67,9 +68,11 @@ function renderWithQuery(component: React.ReactElement) {
   });
   return render(
     <QueryClientProvider client={queryClient}>
-      <AuthProvider>
-        {component}
-      </AuthProvider>
+      <ThemeProvider>
+        <AuthProvider>
+          {component}
+        </AuthProvider>
+      </ThemeProvider>
     </QueryClientProvider>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -153,47 +153,54 @@
   --status-completed-text: var(--color-success-900);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    /* Semantic Colors - Dark Mode */
-    --background: var(--color-neutral-950);
-    --foreground: var(--color-neutral-50);
-    --card: var(--color-neutral-950);
-    --card-foreground: var(--color-neutral-50);
-    --popover: var(--color-neutral-950);
-    --popover-foreground: var(--color-neutral-50);
-    --primary: var(--color-primary-500);
-    --primary-foreground: var(--color-neutral-50);
-    --secondary: var(--color-neutral-800);
-    --secondary-foreground: var(--color-neutral-50);
-    --muted: var(--color-neutral-800);
-    --muted-foreground: var(--color-neutral-400);
-    --accent: var(--color-neutral-800);
-    --accent-foreground: var(--color-neutral-50);
-    --destructive: var(--color-error-500);
-    --destructive-foreground: var(--color-neutral-50);
-    --success: var(--color-success-500);
-    --success-foreground: var(--color-neutral-950);
-    --border: var(--color-neutral-800);
-    --input: var(--color-neutral-800);
-    --ring: var(--color-primary-500);
+[data-theme="dark"] {
+  /* Semantic Colors - Dark Mode */
+  --background: #0f172a;
+  --foreground: #f1f5f9;
+  --card: #1e293b;
+  --card-foreground: #f1f5f9;
+  --popover: #1e293b;
+  --popover-foreground: #f1f5f9;
+  --primary: #60a5fa;
+  --primary-foreground: #f1f5f9;
+  --secondary: #334155;
+  --secondary-foreground: #f1f5f9;
+  --muted: #334155;
+  --muted-foreground: #94a3b8;
+  --accent: #334155;
+  --accent-foreground: #f1f5f9;
+  --destructive: #ef4444;
+  --destructive-foreground: #f1f5f9;
+  --success: #22c55e;
+  --success-foreground: #0f172a;
+  --border: #334155;
+  --input: #334155;
+  --ring: #60a5fa;
 
-    /* Todo Priority Colors - Dark Mode */
-    --priority-low-bg: var(--color-neutral-800);
-    --priority-low-text: var(--color-neutral-300);
-    --priority-medium-bg: var(--color-primary-900);
-    --priority-medium-text: var(--color-primary-300);
-    --priority-high-bg: var(--color-error-900);
-    --priority-high-text: var(--color-error-300);
+  /* Todo Priority Colors - Dark Mode */
+  --priority-low-bg: #334155;
+  --priority-low-text: #cbd5e1;
+  --priority-medium-bg: #1e3a8a;
+  --priority-medium-text: #93c5fd;
+  --priority-high-bg: #7f1d1d;
+  --priority-high-text: #fca5a5;
 
-    /* Todo Status Colors - Dark Mode */
-    --status-pending-bg: var(--color-warning-900);
-    --status-pending-text: var(--color-warning-300);
-    --status-in-progress-bg: var(--color-primary-900);
-    --status-in-progress-text: var(--color-primary-300);
-    --status-completed-bg: var(--color-success-900);
-    --status-completed-text: var(--color-success-300);
-  }
+  /* Todo Status Colors - Dark Mode */
+  --status-pending-bg: #78350f;
+  --status-pending-text: #fcd34d;
+  --status-in-progress-bg: #1e3a8a;
+  --status-in-progress-text: #93c5fd;
+  --status-completed-bg: #14532d;
+  --status-completed-text: #86efac;
+
+  /* Additional theme colors for dark mode */
+  --color-background: #0f172a;
+  --color-surface: #1e293b;
+  --color-surface-hover: #334155;
+  --color-text-primary: #f1f5f9;
+  --color-text-secondary: #94a3b8;
+  --color-border: #334155;
+  --color-primary-500: #60a5fa;
 }
 
 /* Layout utilities */
@@ -250,6 +257,12 @@ body {
   line-height: var(--line-height-normal);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+/* Theme transition for all elements */
+* {
+  transition: background-color 0.3s ease, border-color 0.3s ease;
 }
 
 /* Focus Ring Utilities */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import QueryProvider from "@/providers/QueryProvider";
 import { AuthProvider } from "@/contexts/AuthContext";
+import { ThemeProvider } from "@/contexts/ThemeContext";
 import { ToastProvider } from "@/components/ui/toast";
 import { MSWInit } from "./msw-init";
 
@@ -32,12 +33,14 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <MSWInit />
-        <QueryProvider>
-          <AuthProvider>
-            {children}
-            <ToastProvider />
-          </AuthProvider>
-        </QueryProvider>
+        <ThemeProvider>
+          <QueryProvider>
+            <AuthProvider>
+              {children}
+              <ToastProvider />
+            </AuthProvider>
+          </QueryProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useAuth, useLogout } from '@/hooks/useAuth';
-import { Button } from '@/components/ui';
+import { Button, ThemeToggle } from '@/components/ui';
 import { LogOut, User, Settings } from 'lucide-react';
 
 export function Header() {
@@ -30,6 +30,8 @@ export function Header() {
             <span className="font-medium">{user.username}</span>
             <span className="text-muted-foreground">({user.email})</span>
           </div>
+          
+          <ThemeToggle />
           
           <Link href="/profile">
             <Button

--- a/src/components/layout/__tests__/Header.test.tsx
+++ b/src/components/layout/__tests__/Header.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Header } from '../Header';
 import { useAuth, useLogout } from '@/hooks/useAuth';
+import { ThemeProvider } from '@/contexts/ThemeContext';
 
 jest.mock('@/hooks/useAuth');
 
@@ -15,6 +16,14 @@ const mockUser = {
 
 describe('Header', () => {
   const mockLogout = jest.fn();
+
+  const renderWithTheme = (ui: React.ReactElement) => {
+    return render(
+      <ThemeProvider>
+        {ui}
+      </ThemeProvider>
+    );
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -30,7 +39,7 @@ describe('Header', () => {
       isAuthenticated: false,
     });
 
-    const { container } = render(<Header />);
+    const { container } = renderWithTheme(<Header />);
     expect(container.firstChild).toBeNull();
   });
 
@@ -40,7 +49,7 @@ describe('Header', () => {
       isAuthenticated: true,
     });
 
-    render(<Header />);
+    renderWithTheme(<Header />);
 
     expect(screen.getByText('TODO App')).toBeInTheDocument();
     expect(screen.getByText(mockUser.username)).toBeInTheDocument();
@@ -53,7 +62,7 @@ describe('Header', () => {
       isAuthenticated: true,
     });
 
-    render(<Header />);
+    renderWithTheme(<Header />);
 
     const profileLink = screen.getByRole('link', { name: /profile/i });
     expect(profileLink).toHaveAttribute('href', '/profile');
@@ -66,7 +75,7 @@ describe('Header', () => {
       isAuthenticated: true,
     });
 
-    render(<Header />);
+    renderWithTheme(<Header />);
 
     const logoutButton = screen.getByRole('button', { name: /logout/i });
     await user.click(logoutButton);
@@ -84,7 +93,7 @@ describe('Header', () => {
       isLoading: true,
     });
 
-    render(<Header />);
+    renderWithTheme(<Header />);
 
     const logoutButton = screen.getByRole('button', { name: /logout/i });
     expect(logoutButton).toBeDisabled();

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import React from 'react';
+import { useTheme } from '@/hooks/useTheme';
+import { cn } from '@/lib/cn';
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className={cn(
+        'relative inline-flex h-8 w-14 items-center rounded-full',
+        'bg-neutral-200 dark:bg-neutral-700',
+        'transition-colors duration-300 ease-in-out',
+        'focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+        'hover:bg-neutral-300 dark:hover:bg-neutral-600'
+      )}
+      aria-label={`切り替え: ${theme === 'light' ? 'ダークモード' : 'ライトモード'}`}
+    >
+      <span
+        className={cn(
+          'inline-block h-6 w-6 transform rounded-full',
+          'bg-white shadow-lg',
+          'transition-transform duration-300 ease-in-out',
+          theme === 'dark' ? 'translate-x-7' : 'translate-x-1'
+        )}
+      >
+        <span className="sr-only">
+          {theme === 'light' ? 'ライトモード' : 'ダークモード'}
+        </span>
+      </span>
+      
+      {/* Sun icon */}
+      <svg
+        className={cn(
+          'absolute left-1.5 h-4 w-4',
+          'transition-opacity duration-300',
+          theme === 'light' ? 'opacity-100' : 'opacity-0'
+        )}
+        fill="currentColor"
+        viewBox="0 0 20 20"
+        aria-hidden="true"
+      >
+        <path
+          fillRule="evenodd"
+          d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
+          clipRule="evenodd"
+        />
+      </svg>
+      
+      {/* Moon icon */}
+      <svg
+        className={cn(
+          'absolute right-1.5 h-4 w-4',
+          'transition-opacity duration-300',
+          theme === 'dark' ? 'opacity-100' : 'opacity-0'
+        )}
+        fill="currentColor"
+        viewBox="0 0 20 20"
+        aria-hidden="true"
+      >
+        <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
+      </svg>
+    </button>
+  );
+}

--- a/src/components/ui/__tests__/ThemeToggle.test.tsx
+++ b/src/components/ui/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeToggle } from '../ThemeToggle';
+import { ThemeProvider } from '@/contexts/ThemeContext';
+
+describe('ThemeToggle', () => {
+  const renderWithTheme = (ui: React.ReactElement) => {
+    return render(
+      <ThemeProvider>
+        {ui}
+      </ThemeProvider>
+    );
+  };
+
+  it('renders theme toggle button', () => {
+    renderWithTheme(<ThemeToggle />);
+    const button = screen.getByRole('button', { name: /切り替え: ダークモード/i });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('toggles theme on click', () => {
+    renderWithTheme(<ThemeToggle />);
+    const button = screen.getByRole('button');
+    
+    // Initially in light mode
+    expect(button).toHaveAttribute('aria-label', '切り替え: ダークモード');
+    
+    // Click to switch to dark mode
+    fireEvent.click(button);
+    expect(button).toHaveAttribute('aria-label', '切り替え: ライトモード');
+    
+    // Click to switch back to light mode
+    fireEvent.click(button);
+    expect(button).toHaveAttribute('aria-label', '切り替え: ダークモード');
+  });
+
+  it('has proper accessibility attributes', () => {
+    renderWithTheme(<ThemeToggle />);
+    const button = screen.getByRole('button');
+    const srText = screen.getByText('ライトモード', { selector: '.sr-only' });
+    
+    expect(button).toHaveAttribute('aria-label');
+    expect(srText).toBeInTheDocument();
+  });
+
+  it('shows sun icon in light mode', () => {
+    renderWithTheme(<ThemeToggle />);
+    const button = screen.getByRole('button');
+    const svgs = button.querySelectorAll('svg');
+    const sunIcon = svgs[0];
+    const moonIcon = svgs[1];
+    
+    expect(sunIcon).toHaveClass('opacity-100');
+    expect(moonIcon).toHaveClass('opacity-0');
+  });
+
+  it('shows moon icon in dark mode', () => {
+    renderWithTheme(<ThemeToggle />);
+    const button = screen.getByRole('button');
+    
+    fireEvent.click(button);
+    
+    const svgs = button.querySelectorAll('svg');
+    const sunIcon = svgs[0];
+    const moonIcon = svgs[1];
+    
+    expect(sunIcon).toHaveClass('opacity-0');
+    expect(moonIcon).toHaveClass('opacity-100');
+  });
+});

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -30,3 +30,4 @@ export {
   type ModalContentProps,
   type ModalFooterProps
 } from './Modal';
+export { ThemeToggle } from './ThemeToggle';

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+const THEME_KEY = 'todo-app-theme';
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>('light');
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    
+    // Check localStorage first
+    const savedTheme = localStorage.getItem(THEME_KEY) as Theme | null;
+    
+    if (savedTheme) {
+      setThemeState(savedTheme);
+    } else {
+      // Check system preference if matchMedia is available
+      try {
+        const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+        const prefersDark = mediaQuery?.matches || false;
+        setThemeState(prefersDark ? 'dark' : 'light');
+      } catch {
+        // Default to light mode if matchMedia fails (e.g., in tests)
+        setThemeState('light');
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
+
+    // Apply theme to document
+    document.documentElement.setAttribute('data-theme', theme);
+    
+    // Save to localStorage
+    localStorage.setItem(THEME_KEY, theme);
+  }, [theme, mounted]);
+
+  const toggleTheme = () => {
+    setThemeState((prev) => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  const setTheme = (newTheme: Theme) => {
+    setThemeState(newTheme);
+  };
+
+  // Prevent hydration mismatch by not rendering until mounted
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}

--- a/src/contexts/__tests__/ThemeContext.test.tsx
+++ b/src/contexts/__tests__/ThemeContext.test.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { ThemeProvider, useTheme } from '../ThemeContext';
+
+// Mock matchMedia
+const mockMatchMedia = (matches: boolean) => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+      matches,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+};
+
+// Test component that uses the theme hook
+const TestComponent = () => {
+  const { theme, toggleTheme, setTheme } = useTheme();
+  
+  return (
+    <div>
+      <div data-testid="theme">{theme}</div>
+      <button onClick={toggleTheme}>Toggle Theme</button>
+      <button onClick={() => setTheme('light')}>Set Light</button>
+      <button onClick={() => setTheme('dark')}>Set Dark</button>
+    </div>
+  );
+};
+
+describe('ThemeContext', () => {
+  beforeEach(() => {
+    // Clear localStorage before each test
+    localStorage.clear();
+    jest.clearAllMocks();
+    
+    // Mock document.documentElement.setAttribute
+    jest.spyOn(document.documentElement, 'setAttribute');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('provides theme context values', () => {
+    mockMatchMedia(false);
+    
+    render(
+      <ThemeProvider>
+        <TestComponent />
+      </ThemeProvider>
+    );
+    
+    expect(screen.getByTestId('theme')).toHaveTextContent('light');
+    expect(screen.getByText('Toggle Theme')).toBeInTheDocument();
+  });
+
+  it('toggles theme when toggle is called', () => {
+    mockMatchMedia(false);
+    
+    render(
+      <ThemeProvider>
+        <TestComponent />
+      </ThemeProvider>
+    );
+    
+    const toggleButton = screen.getByText('Toggle Theme');
+    
+    expect(screen.getByTestId('theme')).toHaveTextContent('light');
+    
+    act(() => {
+      fireEvent.click(toggleButton);
+    });
+    
+    expect(screen.getByTestId('theme')).toHaveTextContent('dark');
+    
+    act(() => {
+      fireEvent.click(toggleButton);
+    });
+    
+    expect(screen.getByTestId('theme')).toHaveTextContent('light');
+  });
+
+  it('sets specific theme when setTheme is called', () => {
+    mockMatchMedia(false);
+    
+    render(
+      <ThemeProvider>
+        <TestComponent />
+      </ThemeProvider>
+    );
+    
+    const setDarkButton = screen.getByText('Set Dark');
+    const setLightButton = screen.getByText('Set Light');
+    
+    act(() => {
+      fireEvent.click(setDarkButton);
+    });
+    
+    expect(screen.getByTestId('theme')).toHaveTextContent('dark');
+    
+    act(() => {
+      fireEvent.click(setLightButton);
+    });
+    
+    expect(screen.getByTestId('theme')).toHaveTextContent('light');
+  });
+
+  it('persists theme in localStorage', () => {
+    mockMatchMedia(false);
+    
+    render(
+      <ThemeProvider>
+        <TestComponent />
+      </ThemeProvider>
+    );
+    
+    const toggleButton = screen.getByText('Toggle Theme');
+    
+    act(() => {
+      fireEvent.click(toggleButton);
+    });
+    
+    expect(localStorage.getItem('todo-app-theme')).toBe('dark');
+  });
+
+  it('loads theme from localStorage on mount', () => {
+    mockMatchMedia(false);
+    localStorage.setItem('todo-app-theme', 'dark');
+    
+    render(
+      <ThemeProvider>
+        <TestComponent />
+      </ThemeProvider>
+    );
+    
+    expect(screen.getByTestId('theme')).toHaveTextContent('dark');
+  });
+
+  it('uses system preference when no saved theme', () => {
+    mockMatchMedia(true); // prefers dark mode
+    
+    render(
+      <ThemeProvider>
+        <TestComponent />
+      </ThemeProvider>
+    );
+    
+    expect(screen.getByTestId('theme')).toHaveTextContent('dark');
+  });
+
+  it('applies theme to document element', () => {
+    mockMatchMedia(false);
+    
+    render(
+      <ThemeProvider>
+        <TestComponent />
+      </ThemeProvider>
+    );
+    
+    expect(document.documentElement.setAttribute).toHaveBeenCalledWith('data-theme', 'light');
+    
+    const toggleButton = screen.getByText('Toggle Theme');
+    
+    act(() => {
+      fireEvent.click(toggleButton);
+    });
+    
+    expect(document.documentElement.setAttribute).toHaveBeenCalledWith('data-theme', 'dark');
+  });
+
+  it('throws error when used outside provider', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    
+    expect(() => {
+      render(<TestComponent />);
+    }).toThrow('useTheme must be used within a ThemeProvider');
+    
+    consoleError.mockRestore();
+  });
+});

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,1 @@
+export { useTheme } from '@/contexts/ThemeContext';

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from 'tailwindcss'
 
 const config: Config = {
+  darkMode: ['class', '[data-theme="dark"]'],
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
@@ -14,6 +15,19 @@ const config: Config = {
         card: {
           DEFAULT: 'var(--card)',
           foreground: 'var(--card-foreground)',
+        },
+        neutral: {
+          50: 'var(--color-neutral-50)',
+          100: 'var(--color-neutral-100)',
+          200: 'var(--color-neutral-200)',
+          300: 'var(--color-neutral-300)',
+          400: 'var(--color-neutral-400)',
+          500: 'var(--color-neutral-500)',
+          600: 'var(--color-neutral-600)',
+          700: 'var(--color-neutral-700)',
+          800: 'var(--color-neutral-800)',
+          900: 'var(--color-neutral-900)',
+          950: 'var(--color-neutral-950)',
         },
         popover: {
           DEFAULT: 'var(--popover)',


### PR DESCRIPTION
## Summary
- ライト/ダークモードの切り替え機能とテーマシステムを実装
- ユーザー設定の永続化とシステム設定自動検知に対応
- アクセシビリティを考慮した実装

## 実装内容
### テーマ管理システム
- `ThemeContext`と`useTheme`フックでテーマ状態を管理
- システム設定（prefers-color-scheme）の自動検知
- localStorageでユーザー設定を永続化

### UI実装
- ヘッダーにアニメーション付きテーマ切り替えトグルを追加
- 太陽/月アイコンで視覚的にテーマを表現
- 0.3秒のスムーズな色変化トランジション

### カラーシステム
- CSS変数でライト/ダークモードのカラーパレットを定義
- 全コンポーネントがテーマに対応
- TODOの優先度・ステータス表示も両テーマで最適化

### テスト
- ThemeContextのユニットテスト追加
- ThemeToggleコンポーネントのテスト追加
- 既存テストをThemeProvider対応に更新

## 受け入れ条件（Issue #25）
- [x] ライト・ダークモードがスムーズに切り替わる
- [x] 全コンポーネントが両テーマに対応する
- [x] システム設定に応じて初期テーマが決定される
- [x] ユーザー設定が永続化される
- [x] アクセシビリティが両テーマで保たれる

## スクリーンショット
（ライトモード・ダークモードのスクリーンショットを追加予定）

## テスト
- 全269テストがPASS
- TypeScript型チェック: OK
- ESLint: エラー・警告なし
- ビルド: 成功

Closes #25

🤖 Generated with [Claude Code](https://claude.ai/code)